### PR TITLE
Fix application of the fifty-move rule

### DIFF
--- a/src/binbo_position.erl
+++ b/src/binbo_position.erl
@@ -754,15 +754,7 @@ update_hashmap(Game) ->
 %% https://en.wikipedia.org/wiki/Fifty-move_rule
 -spec is_rule50(bb_game()) -> boolean().
 is_rule50(Game) ->
-    case (get_halfmove(Game) < 50) of
-        true  ->
-            false;
-        false ->
-            case (get_fullmove(Game) < 75) of
-                true  -> false;
-                false -> true
-            end
-    end.
+    get_halfmove(Game) > 99.
 
 %% is_k_vs_k/2
 %% Returns true when:

--- a/test/play_game_SUITE.erl
+++ b/test/play_game_SUITE.erl
@@ -24,6 +24,7 @@
 -export([move_all_pieces/1,
     checkmate_white/1, checkmate_black/1,
     stalemate_white/1, stalemate_black/1,
+    rule50/1,
     castling_kingside/1, castling_queenside/1,
     castling_white_after_king_move/1,
     castling_white_after_rook_move/1,
@@ -150,6 +151,14 @@ stalemate_black(Config) ->
     {ok, continue} = binbo:new_game(Pid, <<"1q2b1b1/8/8/8/8/7k/8/K7 b - -">>),
     {ok, {draw,stalemate}} = binbo:move(Pid, <<"e8g6">>),
     {ok, {draw,stalemate}} = binbo:game_status(Pid),
+    ok.
+
+%% rule50/1
+rule50(Config) ->
+    Pid = get_pid(Config),
+    {ok, continue} = binbo:new_game(Pid, <<"6R1/7k/8/8/1r3B2/5K2/8/8 w - - 99 119">>),
+    {ok, {draw,rule50}} = binbo:move(Pid, <<"Ra4">>),
+    {ok, {draw,rule50}} = binbo:game_status(Pid),
     ok.
 
 %% castling_kingside/1


### PR DESCRIPTION
Here's my first stab at it.

I wasn't sure the best way to exercise `is_rule50/1`, so I ended up testing it via. `:binbo.move/2` in the same way the existing tests test for stalemate.

Let me know if I'm way off, or if there's anything at all you would have done differently!